### PR TITLE
Update SPI pins to match schematic

### DIFF
--- a/ports/esp32/boards/LOLIN_C3_PICO/modules/c3pico.py
+++ b/ports/esp32/boards/LOLIN_C3_PICO/modules/c3pico.py
@@ -8,8 +8,8 @@ import neopixel
 
 # SPI
 SPI_MOSI = const(4)
-SPI_MISO = const(3)
-SPI_CLK = const(2)
+SPI_MISO = const(0)
+SPI_CLK = const(1)
 
 # I2C
 I2C_SDA = const(8)

--- a/ports/esp32/boards/LOLIN_C3_PICO/mpconfigboard.h
+++ b/ports/esp32/boards/LOLIN_C3_PICO/mpconfigboard.h
@@ -9,5 +9,5 @@
 #define MICROPY_HW_I2C0_SDA                 (8)
 
 #define MICROPY_HW_SPI1_MOSI                (4)
-#define MICROPY_HW_SPI1_MISO                (3)
-#define MICROPY_HW_SPI1_SCK                 (2)
+#define MICROPY_HW_SPI1_MISO                (0)
+#define MICROPY_HW_SPI1_SCK                 (1)


### PR DESCRIPTION
It seems that the defined pins did not match the provided schematic. Moreover, the MISO one clashed with the battery ADC. I suppose that this was an error.